### PR TITLE
uncommented dir generation for cgraph

### DIFF
--- a/misc/Cgraph/source/Makefile
+++ b/misc/Cgraph/source/Makefile
@@ -33,8 +33,8 @@ all: $(LIB_FILE) install
 	@echo All done, now do a make install
 
 install:
-#	mkdir -p $(LIB_DIR)
-#	mkdir -p $(INCLUDE_DIR)
+	mkdir -p $(LIB_DIR)
+	mkdir -p $(INCLUDE_DIR)
 	cp $(LIB_FILE) $(LIB_DIR)
 	ranlib $(LIB_DIR)/$(LIB_FILE)
 	cp cgraph.h $(INCLUDE_DIR)


### PR DESCRIPTION
Fixes commented lines in makefile to allow lib directory to be created. Before lib was just a renamed library as no directory existed.